### PR TITLE
ADD: Install headers to include/igloo with CMake install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,8 @@ add_custom_command(TARGET snowhouse-tests
                    POST_BUILD
                    COMMAND snowhouse-tests
                    WORKING_DIRECTORY ./bin)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/igloo
+        DESTINATION include/
+        FILES_MATCHING PATTERN "*.h"
+        PATTERN "igloo/external/snowhouse/example" EXCLUDE)


### PR DESCRIPTION
Add CMake rule to specify where to install igloo headers (with snowhouse)