### PR TITLE
FIX: Compilation error 'base class undefined' 

### DIFF
--- a/igloo/core/registration.h
+++ b/igloo/core/registration.h
@@ -19,18 +19,18 @@
 
 #define IGLOO_CONTEXT_REGISTRATION(contextName) \
   IGLOO_PRIVATE_GENERATE_CONTEXTREGISTRAR(contextName, void) \
-  struct contextName : public ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, false>
+  struct contextName : public igloo::ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, false>
 
 #define IGLOO_CONTEXT_REGISTRATION_ONLY(contextName) \
   IGLOO_PRIVATE_GENERATE_CONTEXTREGISTRAR(contextName, void) \
-  struct contextName : public ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, true, false>
+  struct contextName : public igloo::ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, true, false>
 
 #define IGLOO_CONTEXT_REGISTRATION_SKIP(contextName) \
   IGLOO_PRIVATE_GENERATE_CONTEXTREGISTRAR(contextName, void) \
-  struct contextName : public ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, true>
+  struct contextName : public igloo::ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, true>
 
 #define IGLOO_PARENT_CONTEXT_REGISTRATION(contextName) \
-  struct contextName : public ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, false>
+  struct contextName : public igloo::ContextProvider<contextName, IGLOO_CURRENT_CONTEXT, IGLOO_ROOT_CONTEXT, false, false>
 
 #define IGLOO_SUBCONTEXT_REGISTRATION(contextName, baseContextName) \
   IGLOO_PRIVATE_GENERATE_CONTEXTREGISTRAR(contextName, baseContextName) \
@@ -41,7 +41,7 @@
   { \
     SpecRegistrar_##specName() \
     { \
-	  ContextRegistry<IGLOO_CURRENT_CONTEXT>::RegisterSpec(#specName, &IGLOO_CURRENT_CONTEXT::specName, skip, only); \
+	  igloo::ContextRegistry<IGLOO_CURRENT_CONTEXT>::RegisterSpec(#specName, &IGLOO_CURRENT_CONTEXT::specName, skip, only); \
     } \
   } SpecRegistrar_##specName; \
   virtual void specName()
@@ -60,7 +60,7 @@
     {\
       AttributeRegistrar_##IGLOO_CURRENT_CONTEXT()\
       {\
-        ContextAttributeStorage<IGLOO_CURRENT_CONTEXT>::Set(name, value);\
+        igloo::ContextAttributeStorage<IGLOO_CURRENT_CONTEXT>::Set(name, value);\
       }\
     } AttributeRegistrar_##IGLOO_CURRENT_CONTEXT;
 


### PR DESCRIPTION
if 'using namespace igloo' is not used in the test file, the compiler issue a compilation error 'base class undefined' adding the namespace 'igloo' to the registration macros fix this issue
