### PR TITLE
Fix all warnings reported in issues (and then some)

### DIFF
--- a/igloo/core/contextprovider.h
+++ b/igloo/core/contextprovider.h
@@ -71,6 +71,16 @@ namespace igloo {
     //
     typedef InnerContext IGLOO_CURRENT_CONTEXT;
 
+    NestedContextProvider()
+      : m_outerContext(0)
+    {
+    }
+
+    ~NestedContextProvider()
+    {
+      delete m_outerContext;
+    }
+
     static bool IsContextMarkedAsOnly()
     {
       return ISONLY || 
@@ -85,11 +95,11 @@ namespace igloo {
 
     virtual OuterContext& Parent()
     {
-      if(m_outerContext.get() == 0)
+      if(m_outerContext == 0)
       {
-        m_outerContext = std::auto_ptr<OuterContext>(CreateIglooContext<OuterContext>());
+        m_outerContext = CreateIglooContext<OuterContext>();
       }
-      return *(m_outerContext.get());
+      return *m_outerContext;
     }
 
     virtual void IglooFrameworkSetUp()
@@ -111,7 +121,7 @@ namespace igloo {
         return new ContextType();
       }
 
-    std::auto_ptr<OuterContext> m_outerContext;
+    OuterContext* m_outerContext;
   };
 
   //

--- a/igloo/core/outputters/testresultsoutput.h
+++ b/igloo/core/outputters/testresultsoutput.h
@@ -15,6 +15,7 @@ namespace igloo {
       std::ostream& output;
     public:
       TestResultsOutput(std::ostream& outstream = std::cout) : output(outstream) {}
+      virtual ~TestResultsOutput() {}
       virtual void PrintResult(const TestResults& results) const = 0;
 
     private:

--- a/igloo/core/outputters/testresultsoutput.h
+++ b/igloo/core/outputters/testresultsoutput.h
@@ -17,8 +17,8 @@ namespace igloo {
       TestResultsOutput(std::ostream& outstream = std::cout) : output(outstream) {}
       virtual void PrintResult(const TestResults& results) const = 0;
 
-  private:
-	  TestResultsOutput& operator=(const TestResultsOutput&) { return *this; }
+    private:
+      TestResultsOutput& operator=(const TestResultsOutput&);
   };
 }
 

--- a/igloo/core/outputters/xmlwriter.h
+++ b/igloo/core/outputters/xmlwriter.h
@@ -61,7 +61,7 @@ namespace igloo {
 
       friend class XmlElement;
 
-	  XmlWriter& operator=(const XmlWriter&) { return *this; }
+      XmlWriter& operator=(const XmlWriter&);
   };
 
   //
@@ -178,7 +178,7 @@ namespace igloo {
           }
       }
 
-	  XmlElement& operator=(const XmlElement&) { return *this; }
+      XmlElement& operator=(const XmlElement&);
   };
 }
 

--- a/igloo/core/testresults.h
+++ b/igloo/core/testresults.h
@@ -20,12 +20,12 @@ namespace igloo {
 
       int NumberOfSucceededTests() const
       {
-        return succeededTests_.size();
+        return static_cast<int>(succeededTests_.size());
       }
 
       int NumberOfFailedTests() const
       {
-        return failedTests_.size();
+        return static_cast<int>(failedTests_.size());
       }
 
       void AddResult(const SucceededTestResult result)

--- a/igloo/core/testrunner.h
+++ b/igloo/core/testrunner.h
@@ -44,25 +44,25 @@ namespace igloo {
           return 0;
         }
 
-        std::auto_ptr<TestResultsOutput> output;
+        TestResultsOutput* output = 0;
         if(c::has_option("output", opt))
         {
           std::string val = c::option_value("output", opt);
           if(val == "vs")
           {
-            output = std::auto_ptr<TestResultsOutput>(new VisualStudioResultsOutput());
+            output = new VisualStudioResultsOutput();
           }
           else if(val == "color")
           {
-            output = std::auto_ptr<TestResultsOutput>(new ColoredConsoleTestResultsOutput());
+            output = new ColoredConsoleTestResultsOutput();
           }
           else if(val == "xunit")
           {
-            output = std::auto_ptr<TestResultsOutput>(new XUnitResultsOutput());
+            output = new XUnitResultsOutput();
           }
           else if(val == "default")
           {
-            output = std::auto_ptr<TestResultsOutput>(new DefaultTestResultsOutput());
+            output = new DefaultTestResultsOutput();
           }
           else
           {
@@ -72,16 +72,17 @@ namespace igloo {
         }
         else
         {
-          output = std::auto_ptr<TestResultsOutput>(new DefaultTestResultsOutput());
+          output = new DefaultTestResultsOutput();
         }
 
-
-        TestRunner runner(*(output.get()));
+        TestRunner runner(*output);
 
         MinimalProgressTestListener progressOutput;
         runner.AddListener(&progressOutput);
 
-        return runner.Run();
+        int res = runner.Run();
+        delete output;
+        return res;
       }
 
 

--- a/igloo/core/testrunner.h
+++ b/igloo/core/testrunner.h
@@ -187,10 +187,8 @@ namespace igloo {
         return contextRunners;
       }
 
-	private:
-		TestRunner& operator=(const TestRunner&) { return *this; }
+      TestRunner& operator=(const TestRunner&);
 
-    private:
       const TestResultsOutput& output_;
       TestListenerAggregator listenerAggregator_;
   };

--- a/tests/bdd_tests.cpp
+++ b/tests/bdd_tests.cpp
@@ -22,6 +22,7 @@ namespace igloo_example {
   struct Player
   {
     Player(const char* name) : name_(name) {}
+    Player(const Player& rhs) : name_(rhs.name_) {}
 
     const std::string name_;
 

--- a/tests/bdd_tests.cpp
+++ b/tests/bdd_tests.cpp
@@ -27,7 +27,7 @@ namespace igloo_example {
     const std::string name_;
 
   private:
-	  Player& operator=(const Player&) { return *this; }
+    Player& operator=(const Player&);
   };
   
   inline bool operator==(const Player& lhs, const Player& rhs)

--- a/tests/coloredconsoletestresultsoutput_tests.cpp
+++ b/tests/coloredconsoletestresultsoutput_tests.cpp
@@ -10,13 +10,18 @@ using namespace igloo;
 
 Context(ColoredConsoleTestResultsOutput_EmptyTestRun)
 {
-  std::auto_ptr<ColoredConsoleTestResultsOutput> output;
+  ColoredConsoleTestResultsOutput* output;
   std::stringstream resulting_stream;
   TestResults results;
 
   void SetUp()
   {
-    output = std::auto_ptr<ColoredConsoleTestResultsOutput>(new ColoredConsoleTestResultsOutput(resulting_stream));
+    output = new ColoredConsoleTestResultsOutput(resulting_stream);
+  }
+
+  void TearDown()
+  {
+    delete output;
   }
 
   Spec(OutputsASummaryLineWithNoTests)

--- a/tests/defaulttestresultsoutput_tests.cpp
+++ b/tests/defaulttestresultsoutput_tests.cpp
@@ -11,13 +11,18 @@ using namespace igloo;
 
 Context(DefaultTestResultsOutput_EmptyTestRun)
 {
-  std::auto_ptr<DefaultTestResultsOutput> output;
+  DefaultTestResultsOutput* output;
   std::stringstream resulting_stream;
   TestResults results;
 
   void SetUp()
   {
-    output = std::auto_ptr<DefaultTestResultsOutput>(new DefaultTestResultsOutput(resulting_stream));
+    output = new DefaultTestResultsOutput(resulting_stream);
+  }
+
+  void TearDown()
+  {
+    delete output;
   }
 
   Spec(OutputsASummaryLineWithNoTests)

--- a/tests/running_subsets_of_tests.cpp
+++ b/tests/running_subsets_of_tests.cpp
@@ -22,7 +22,12 @@ Context(TestRunner_)
   {
     contextRunner_Only.MarkAsOnly();
     contextRunner_Skip.MarkAsSkip();
-    runner = std::auto_ptr<TestRunner>(new TestRunner(nullOutput));
+    runner = new TestRunner(nullOutput);
+  }
+
+  void TearDown()
+  {
+    delete runner;
   }
 
   Context(no_only_specified)
@@ -78,7 +83,7 @@ Context(TestRunner_)
   fakes::FakeContextRunner contextRunner;
   fakes::FakeContextRunner contextRunner_Only;
   fakes::FakeContextRunner contextRunner_Skip;
-  std::auto_ptr<TestRunner> runner;
+  TestRunner* runner;
   fakes::NullTestResultsOutput nullOutput;
   TestRunner::ContextRunners contextRunners;
 };

--- a/tests/testlistener_tests.cpp
+++ b/tests/testlistener_tests.cpp
@@ -14,7 +14,7 @@ using namespace igloo;
 Context(registering_a_test_listener)
 {
   fakes::NullTestResultsOutput nullOutput;
-  std::auto_ptr<TestRunner> runner;
+  TestRunner* runner;
   TestRunner::ContextRunners contextRunners;
   fakes::FakeTestListener listener;
   fakes::FakeContextRunner contextRunner;
@@ -23,10 +23,15 @@ Context(registering_a_test_listener)
 
   void SetUp()
   {
-    runner = std::auto_ptr<TestRunner>(new TestRunner(nullOutput));
+    runner = new TestRunner(nullOutput);
     runner->AddListener(&listener);
 
     contextRunners.push_back(&contextRunner);
+  }
+
+  void TearDown()
+  {
+    delete runner;
   }
 
   Spec(a_callback_is_made_when_the_test_run_starts)

--- a/tests/visualstudiotestresultsoutput_tests.cpp
+++ b/tests/visualstudiotestresultsoutput_tests.cpp
@@ -11,13 +11,18 @@ using namespace igloo;
 
 Context(VisualStudioResultsOutput_EmptyTestRun)
 {
-  std::auto_ptr<VisualStudioResultsOutput> output;
+  VisualStudioResultsOutput* output;
   std::stringstream resulting_stream;
   TestResults results;
   
   void SetUp()
   {
-    output = std::auto_ptr<VisualStudioResultsOutput>(new VisualStudioResultsOutput(resulting_stream));
+    output = new VisualStudioResultsOutput(resulting_stream);
+  }
+
+  void TearDown()
+  {
+    delete output;
   }
 
   Spec(it_should_display_a_summary_line_with_no_tests_run)

--- a/tests/xmlwritter_tests.cpp
+++ b/tests/xmlwritter_tests.cpp
@@ -19,6 +19,11 @@ Context(EmptyXMWriter)
     ws = new XmlWriter(ss);
   }
 
+  void TearDown()
+  {
+    delete ws;
+  }
+
   Spec(Should_generate_XML_header_when_empty)
   {
     Assert::That(ss.str(), Is().StartingWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>"));

--- a/tests/xunittestresultsoutput_tests.cpp
+++ b/tests/xunittestresultsoutput_tests.cpp
@@ -11,13 +11,18 @@ using namespace igloo;
 
 Context(XUnitResultsOutput_EmptyTestRun)
 {
-  std::auto_ptr<XUnitResultsOutput> output;
+  XUnitResultsOutput* output;
   std::stringstream resulting_stream;
   TestResults results;
   
   void SetUp()
   {
-    output = std::auto_ptr<XUnitResultsOutput>(new XUnitResultsOutput(resulting_stream));
+    output = new XUnitResultsOutput(resulting_stream);
+  }
+
+  void TearDown()
+  {
+    delete output;
   }
 
   Spec(xml_output_should_content_testsuite_tag_with_tests_attr_set_to_0)


### PR DESCRIPTION
I found an issue report in my inbox, and figured I'd hack on Igloo a little :-)

This patch series should close issues #13, #21 and #24 as well as a few warnings I tripped on in my environment.

Built with:

* GCC 9.3.0
* Clang-15 (trunk)
* Clang-15 with `-std=c++98` to prove that '98 mode still works
* Clang-15 with `-fsanitize=address` to find and fix memory leak

Ran into a little uninitialized warning in snowhouse that I didn't fix, because submodules. Saved as an exercise for the reader.